### PR TITLE
reduce 6lowpan traffic while provisioning constrained devices

### DIFF
--- a/src/fdm_common.h
+++ b/src/fdm_common.h
@@ -169,4 +169,17 @@ typedef struct
     //! \}
 } Verification;
 
+
+
+/**
+ * Constrained Device information.
+ */
+typedef struct {
+    //! \{
+    bool isDevicePresent;
+    bool isFlowObjectInstanceRegistered;
+    bool isFlowAccessInstanceRegistered;
+    //! \}
+} DeviceStatus;
+
 #endif  /* FDM_COMMON_H */

--- a/src/fdm_get_client_list.c
+++ b/src/fdm_get_client_list.c
@@ -77,8 +77,8 @@ static void ListClients(const AwaServerSession *session, json_object *respObj)
             while(AwaClientIterator_Next(clientIterator))
             {
                 const char *clientID = AwaClientIterator_GetClientID(clientIterator);
-
-                json_bool provisionStatus = IsDeviceProvisioned(session, clientID) ? 1 : 0;
+                const AwaServerListClientsResponse *response = AwaServerListClientsOperation_GetResponse(operation, clientID);
+                json_bool provisionStatus = IsFlowAccessInstanceRegistered(session, response) ? 1 : 0;
                 json_object *clientObj = json_object_new_object();
                 json_object_object_add(clientObj, "clientId", json_object_new_string(clientID));
                 json_object_object_add(clientObj, "is_device_provisioned", json_object_new_boolean(provisionStatus));


### PR DESCRIPTION
Instead of reading flowaccess object from constrained device, check whether flow access instance
has been registered on the local awa server to confirm if the device is provisioned or not.

Signed-off-by: Rahul Daga <Rahul.Daga@imgtec.com>